### PR TITLE
Add Detailed Report; Cleanup Types; Add Prettier to project;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules
 dist
 .vscode
 .DS_Store
-
+.idea/

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ You run this command with `injectAxe()` either in your test, or in a `beforeEach
 
 ```js
 beforeAll(async () => {
-  browser = await chromium.launch();
-  page = await browser.newPage();
-  await page.goto(`http://localhost:3000/login`);
-  await injectAxe(page);
-});
+  browser = await chromium.launch()
+  page = await browser.newPage()
+  await page.goto(`http://localhost:3000/login`)
+  await injectAxe(page)
+})
 ```
 
 ### configureAxe
@@ -74,9 +74,9 @@ it('Has no detectable a11y violations on load (custom configuration)', async () 
     checks: [Object],
     rules: [Object],
     locale: Object,
-  });
-  await checkA11y();
-});
+  })
+  await checkA11y()
+})
 ```
 
 ### checkA11y
@@ -97,7 +97,7 @@ Defines the scope of the analysis - the part of the DOM that you would like to a
 
 Set of options passed into rules or checks, temporarily modifying them. This contrasts with axe.configure, which is more permanent.
 
-The keys consist of [those accepted by `axe.run`'s options argument](https://www.deque.com/axe/documentation/api-documentation/#parameters-axerun) as well as a custom `includedImpacts` key.
+The keys consist of [those accepted by `axe.run`'s options argument](https://www.deque.com/axe/documentation/api-documentation/#parameters-axerun) as well as custom `includedImpacts` and `detailedReport` keys.
 
 The `includedImpacts` key is an array of strings that map to `impact` levels in violations. Specifying this array will only include violations where the impact matches one of the included values. Possible impact values are "minor", "moderate", "serious", or "critical".
 
@@ -105,6 +105,8 @@ Filtering based on impact in combination with the `skipFailures` argument allows
 e-effects, such as adding custom output to the terminal.
 
 **NOTE:** _This respects the `includedImpacts` filter and will only execute with violations that are included._
+
+The `detailedReport` key is a boolean that defaults to `true`. In addition to the summary it prints out a per node report and the violations to be able to hone in on the failures.
 
 ##### skipFailures (optional, defaults to false)
 
@@ -115,23 +117,23 @@ Disables assertions based on violations and only logs violations to the console 
 #### Basic usage
 
 ```js
-import { chromium, Browser, Page } from 'playwright';
-import { injectAxe, checkA11y } from 'axe-playwright';
+import { chromium, Browser, Page } from 'playwright'
+import { injectAxe, checkA11y } from 'axe-playwright'
 
-let browser: Browser;
-let page: Page;
+let browser: Browser
+let page: Page
 
 describe('Playwright web page accessibility test', () => {
   beforeAll(async () => {
-    browser = await chromium.launch();
-    page = await browser.newPage();
-    await page.goto(`file://${process.cwd()}/test/site.html`);
-    await injectAxe(page);
-  });
+    browser = await chromium.launch()
+    page = await browser.newPage()
+    await page.goto(`file://${process.cwd()}/test/site.html`)
+    await injectAxe(page)
+  })
 
   it('simple accessibility run', async () => {
-    await checkA11y(page);
-  });
+    await checkA11y(page)
+  })
 
   it('check a11y for the whole page and axe run options', async () => {
     await checkA11y(page, null, {
@@ -141,8 +143,8 @@ describe('Playwright web page accessibility test', () => {
           values: ['wcag2a'],
         },
       },
-    });
-  });
+    })
+  })
 
   it('check a11y for the specific element', async () => {
     await checkA11y(page, 'input[name="password"]', {
@@ -152,13 +154,13 @@ describe('Playwright web page accessibility test', () => {
           values: ['wcag2a'],
         },
       },
-    });
-  });
+    })
+  })
 
   afterAll(async () => {
-    await browser.close();
-  });
-});
+    await browser.close()
+  })
+})
 ```
 
 This custom logging behavior results in terminal output like this:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { ElementContext, ImpactValue, RunOptions } from 'axe-core'
 import { Page } from 'playwright'
+import { ConfigOptions } from './src'
 
 export interface axeOptionsConfig {
   axeOptions: RunOptions
@@ -18,6 +19,7 @@ export function injectAxe(page: Page): void
 
 /**
  * Performs accessibility checks in the web page
+ * @param page
  * @param context
  * @param options
  * @param skipFailures
@@ -31,6 +33,7 @@ export function checkA11y(
 
 /**
  * configure different axe configurations
+ * @param page
  * @param options
  */
-export function configureAxe(page: Page, options?: RunOptions): void
+export function configureAxe(page: Page, options?: ConfigOptions): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
-import { ElementContext, ImpactValue, RunOptions } from 'axe-core';
-import { Page } from 'playwright';
+import { ElementContext, ImpactValue, RunOptions } from 'axe-core'
+import { Page } from 'playwright'
 
 export interface axeOptionsConfig {
-  axeOptions: RunOptions;
+  axeOptions: RunOptions
 }
 
-export type Options = { includedImpacts?: ImpactValue[] } & axeOptionsConfig;
+export type Options = { includedImpacts?: ImpactValue[] } & axeOptionsConfig
 
 declare module 'axe-core' {
   interface Node {}
@@ -14,7 +14,7 @@ declare module 'axe-core' {
 /**
  * Injects axe into browser-context
  */
-export function injectAxe(page: Page): void;
+export function injectAxe(page: Page): void
 
 /**
  * Performs accessibility checks in the web page
@@ -26,11 +26,11 @@ export function checkA11y(
   page: Page,
   context?: ElementContext,
   options?: Options,
-  skipFailures?: boolean
-): void;
+  skipFailures?: boolean,
+): void
 
 /**
  * configure different axe configurations
  * @param options
  */
-export function configureAxe(page: Page, options?: RunOptions): void;
+export function configureAxe(page: Page, options?: RunOptions): void

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,4 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6909,6 +6909,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://widen.jfrog.io/widen/api/npm/npm-virtual/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha1-1tVigkVSQ/L5LMFxZpLAiqMVItQ=",
+      "dev": true
+    },
     "pretty-format": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "prebuild": "rm -rf dist",
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "format": "npx prettier --write ."
   },
   "peerDependencies": {
     "playwright": ">1.0.0"
@@ -33,6 +34,7 @@
     "jest": "^25.5.4",
     "jest-playwright-preset": "^0.2.3",
     "playwright": "^1.1.1",
+    "prettier": "^2.0.5",
     "ts-jest": "^25.5.1",
     "typescript": "^3.8.3"
   },
@@ -47,5 +49,10 @@
   "bugs": {
     "url": "https://github.com/abhinaba-ghosh/axe-playwright/issues"
   },
-  "homepage": "https://github.com/abhinaba-ghosh/axe-playwright#readme"
+  "homepage": "https://github.com/abhinaba-ghosh/axe-playwright#readme",
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all",
+    "semi": false
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,88 +1,96 @@
-import { Page } from 'playwright';
-import * as fs from 'fs';
-import assert from 'assert';
-import { ElementContext, ImpactValue, RunOptions } from 'axe-core';
+import { Page } from 'playwright'
+import * as fs from 'fs'
+import assert from 'assert'
+import {
+  AxeResults,
+  ElementContext,
+  ImpactValue,
+  RunOptions,
+  NodeResult,
+  Result,
+  Spec,
+} from 'axe-core'
 
 declare global {
   interface Window {
-    axe: any;
+    axe: any
   }
 }
 
 interface axeOptionsConfig {
-  axeOptions: RunOptions;
+  axeOptions: RunOptions
 }
 
-type Options = { includedImpacts?: ImpactValue[] } & axeOptionsConfig;
+type Options = {
+  includedImpacts?: ImpactValue[]
+  detailedReport?: boolean
+} & axeOptionsConfig
 
 export const injectAxe = async (page: Page) => {
   const axe: string = fs.readFileSync(
     'node_modules/axe-core/axe.min.js',
-    'utf8'
-  );
-  await page.evaluate((axe: string) => window.eval(axe), axe);
-};
+    'utf8',
+  )
+  await page.evaluate((axe: string) => window.eval(axe), axe)
+}
 
 export const configureAxe = async (
   page: Page,
-  configurationOptions: RunOptions = {}
+  configurationOptions: Spec = {},
 ) => {
-  await page.evaluate(() => window.axe.configure(configurationOptions));
-};
+  await page.evaluate(
+    (configOptions: Spec) => window.axe.configure(configOptions),
+    configurationOptions,
+  )
+}
 
 export const checkA11y = async (
   page: Page,
-  context?: ElementContext | null,
-  options?: Options,
-  skipFailures: boolean = false
+  context: ElementContext | undefined = undefined,
+  options: Options | undefined = undefined,
+  skipFailures: boolean = false,
 ) => {
-  let violations: any = await page.evaluate(
+  let axeResults: AxeResults = await page.evaluate(
     ([context, options]) => {
-      let isEmptyObjectorNull = function (value: any) {
-        if (value == null) return true;
-        return (
-          Object.entries(value).length === 0 && value.constructor === Object
-        );
-      };
-
-      if (isEmptyObjectorNull(context)) context = undefined;
-      if (isEmptyObjectorNull(options)) options = undefined;
-      const axeOptions: {} = options ? options['axeOptions'] : {};
-      return window.axe.run(context || window.document, axeOptions);
+      const axeOptions: RunOptions = options ? options['axeOptions'] : {}
+      return window.axe.run(context || window.document, axeOptions)
     },
-    [context, options]
-  );
+    [context, options],
+  )
 
-  const { includedImpacts } = options || {};
-  violations = getImpactedViolations(violations.violations, includedImpacts);
+  const { includedImpacts, detailedReport = true } = options || {}
+  const violations: Result[] = getImpactedViolations(
+    axeResults.violations,
+    includedImpacts,
+  )
 
-  printViolationTerminal(violations);
-  testResultDependsOnViolations(violations, skipFailures);
-};
+  printViolationTerminal(violations, detailedReport)
+  testResultDependsOnViolations(violations, skipFailures)
+}
 
 const getImpactedViolations = (
-  violations: any,
-  includedImpacts: ImpactValue[] | undefined
+  violations: Result[],
+  includedImpacts: ImpactValue[] = [],
 ) => {
-  return includedImpacts &&
-    Array.isArray(includedImpacts) &&
-    Boolean(includedImpacts.length)
-    ? violations.filter((v: any) => includedImpacts.includes(v.impact))
-    : violations;
-};
+  return Array.isArray(includedImpacts) && includedImpacts.length
+    ? violations.filter(
+        (v: Result) => v.impact && includedImpacts.includes(v.impact),
+      )
+    : violations
+}
 
 const testResultDependsOnViolations = (
-  violations: any,
-  skipFailures: boolean
+  violations: Result[],
+  skipFailures: boolean,
 ) => {
   if (!skipFailures) {
-    assert.equal(
+    assert.strictEqual(
       violations.length,
       0,
       `${violations.length} accessibility violation${
         violations.length === 1 ? '' : 's'
-      } ${violations.length === 1 ? 'was' : 'were'} detected`
-    );
+      } ${violations.length === 1 ? 'was' : 'were'} detected`,
+    )
   } else {
     if (violations.length) {
       console.log({
@@ -90,21 +98,59 @@ const testResultDependsOnViolations = (
         message: `${violations.length} accessibility violation${
           violations.length === 1 ? '' : 's'
         } ${violations.length === 1 ? 'was' : 'were'} detected`,
-      });
+      })
     }
   }
-};
+}
 
-const printViolationTerminal = (violations: any) => {
+interface NodeViolation {
+  target: string
+  html: string
+  violation: string
+}
+
+const describeViolations = (violations: Result[]) => {
+  const nodeViolations: NodeViolation[] = []
+  const prefix = 'Fix any of the following:\n  '
+
+  violations.map(({ nodes }) => {
+    nodes.forEach((node: NodeResult) => {
+      const failure =
+        node.failureSummary && node.failureSummary.startsWith(prefix)
+          ? node.failureSummary.slice(prefix.length)
+          : node.failureSummary || ''
+
+      nodeViolations.push({
+        html: node.html,
+        target: JSON.stringify(node.target),
+        violation: failure,
+      })
+    })
+  })
+
+  return nodeViolations
+}
+
+const printViolationTerminal = (
+  violations: Result[],
+  detailedReport: boolean,
+) => {
   const violationData = violations.map(({ id, impact, description, nodes }) => {
     return {
       id,
       impact,
       description,
       nodes: nodes.length,
-    };
-  });
+    }
+  })
+
   if (violationData.length > 0) {
-    console.table(violationData);
+    // summary
+    console.table(violationData)
+    if (detailedReport) {
+      const nodeViolations = describeViolations(violations)
+      // per node
+      console.table(nodeViolations)
+    }
   }
-};
+}

--- a/test/a11y.spec.ts
+++ b/test/a11y.spec.ts
@@ -1,16 +1,16 @@
-import { chromium, Browser, Page } from 'playwright';
-import { injectAxe, checkA11y } from '../src';
+import { chromium, Browser, Page } from 'playwright'
+import { injectAxe, checkA11y } from '../src'
 
-let browser: Browser;
-let page: Page;
+let browser: Browser
+let page: Page
 
 describe('Playwright web page accessibility test', () => {
   beforeAll(async () => {
-    browser = await chromium.launch();
-    page = await browser.newPage();
-    await page.goto(`file://${process.cwd()}/test/site.html`);
-    await injectAxe(page);
-  });
+    browser = await chromium.launch()
+    page = await browser.newPage()
+    await page.goto(`file://${process.cwd()}/test/site.html`)
+    await injectAxe(page)
+  })
 
   it('check a11y', async () => {
     await checkA11y(
@@ -24,11 +24,11 @@ describe('Playwright web page accessibility test', () => {
           },
         },
       },
-      true
-    );
-  });
+      true,
+    )
+  })
 
   afterAll(async () => {
-    await browser.close();
-  });
-});
+    await browser.close()
+  })
+})


### PR DESCRIPTION
- [x] Add optional detailed report that is enabled by default to describe which nodes are failing
- [x] Clean/tighten up types
- [x] Fix `configureAxe` to pass the configurationOptions into the method. When trying to use it complained that `configurationOptions` was undefined
- [x] Add prettier to project to autoformat code. Hope that's ok. Can always remove or change this as well, open to whatever

# Example Output of one element with two failures
<img width="2250" alt="image" src="https://user-images.githubusercontent.com/43150303/89428908-876a0480-d702-11ea-903b-907940a85a7e.png">

