### PR TITLE
Bug: Type Declaration file void vs Promise<void>

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare module 'axe-core' {
 /**
  * Injects axe into browser-context
  */
-export function injectAxe(page: Page): void
+export function injectAxe(page: Page): Promise<void>
 
 /**
  * Performs accessibility checks in the web page
@@ -33,11 +33,11 @@ export function checkA11y(
   context?: ElementContext,
   options?: Options,
   skipFailures?: boolean,
-): void
+): Promise<void>
 
 /**
  * configure different axe configurations
  * @param page
  * @param options
  */
-export function configureAxe(page: Page, options?: ConfigOptions): void
+export function configureAxe(page: Page, options?: ConfigOptions): Promise<void>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,27 @@
-import { ElementContext, ImpactValue, RunOptions } from 'axe-core'
+import {
+  Check,
+  ElementContext,
+  ImpactValue,
+  Locale,
+  Rule,
+  RunOptions,
+} from 'axe-core'
 import { Page } from 'playwright'
-import { ConfigOptions } from './src'
 
 export interface axeOptionsConfig {
   axeOptions: RunOptions
+}
+
+export interface ConfigOptions {
+  branding?: {
+    brand?: string
+    application?: string
+  }
+  reporter?: 'v1' | 'v2' | 'no-passes'
+  checks?: Check[]
+  rules?: Rule[]
+  locale?: Locale
+  axeVersion?: string
 }
 
 export type Options = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export interface ConfigOptions {
   axeVersion?: string
 }
 
-export const injectAxe = async (page: Page) => {
+export const injectAxe = async (page: Page): Promise<void> => {
   const axe: string = fs.readFileSync(
     'node_modules/axe-core/axe.min.js',
     'utf8',
@@ -52,7 +52,7 @@ export const injectAxe = async (page: Page) => {
 export const configureAxe = async (
   page: Page,
   configurationOptions: ConfigOptions = {},
-) => {
+): Promise<void> => {
   await page.evaluate(
     (configOptions: Spec) => window.axe.configure(configOptions),
     configurationOptions as Spec,
@@ -64,7 +64,7 @@ export const checkA11y = async (
   context: ElementContext | undefined = undefined,
   options: Options | undefined = undefined,
   skipFailures: boolean = false,
-) => {
+): Promise<void> => {
   let axeResults: AxeResults = await page.evaluate(
     ([context, options]) => {
       const axeOptions: RunOptions = options ? options['axeOptions'] : {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,42 +3,18 @@ import * as fs from 'fs'
 import assert from 'assert'
 import {
   AxeResults,
-  Check,
   ElementContext,
   ImpactValue,
-  Locale,
   Result,
-  Rule,
   RunOptions,
   Spec,
 } from 'axe-core'
+import { ConfigOptions, Options } from '../index'
 
 declare global {
   interface Window {
     axe: any
   }
-}
-
-interface axeOptionsConfig {
-  axeOptions: RunOptions
-}
-
-type Options = {
-  includedImpacts?: ImpactValue[]
-  detailedReport?: boolean
-  detailedReportOptions?: { html?: boolean }
-} & axeOptionsConfig
-
-export interface ConfigOptions {
-  branding?: {
-    brand?: string
-    application?: string
-  }
-  reporter?: 'v1' | 'v2' | 'no-passes'
-  checks?: Check[]
-  rules?: Rule[]
-  locale?: Locale
-  axeVersion?: string
 }
 
 export const injectAxe = async (page: Page): Promise<void> => {


### PR DESCRIPTION
Type declaration file claimed `void` for `async` functions that should be returning `Promise<void>`