### PR TITLE
Use playwright-core for peer dependency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ import {
   Rule,
   RunOptions,
 } from 'axe-core'
-import { Page } from 'playwright'
+import { Page } from 'playwright-core'
 
 export interface axeOptionsConfig {
   axeOptions: RunOptions

--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
     "release": "npm cache clean --force && npm version patch && npm publish --force"
   },
   "peerDependencies": {
-    "playwright": ">1.0.0"
+    "playwright-core": ">1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "playwright-core": {
+      "optional": true
+    }
   },
   "author": "Abhinaba Ghosh",
   "contributors": [
@@ -41,7 +46,6 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@types/axe-core": "^2.0.7",
     "axe-core": "^4.0.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,6 @@
   "peerDependencies": {
     "playwright-core": ">1.0.0"
   },
-  "peerDependenciesMeta": {
-    "playwright-core": {
-      "optional": true
-    }
-  },
   "author": "Abhinaba Ghosh",
   "contributors": [
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright'
+import { Page } from 'playwright-core'
 import * as fs from 'fs'
 import assert from 'assert'
 import {


### PR DESCRIPTION
Currently, `playwright` is marked as a peer dependency of this library.  In some of my projects I use the `playwright-chromium` package instead of the `playwright` package as I only need Chrome and not the other browsers.  This causes peer dependency warnings as axe-playwright specifies `playwright` as a peer dependency.

This PR updates axe-playwright to have a peer dependency on `playwright-core` instead.  This still allows importing the types from playwright so this is a completely non-breaking change as users who have `playwright` installed also have `playwright-core`, but now users can also choose `playwright-chromium` or `playwright-firefox` instead of the full `playwright` package.

Thanks for the awesome library by the way!