### PR TITLE
Add default reporter impl to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,14 @@ export default interface Reporter {
   report(violations: Result[]): Promise<void>
 }
 
+/**
+ * Default implementation of a reporter which prints a summary to the console.
+ */
+export class DefaultTerminalReporter implements Reporter {
+  constructor(detailedReport: boolean | undefined, includeHtml: boolean | undefined)
+  report(violations: Result[]): Promise<void>
+}
+
 export type Options = {
   includedImpacts?: ImpactValue[]
   detailedReport?: boolean


### PR DESCRIPTION
Add `DefaultTerminalReporter` to types to allow using the default reporter implementation externally.

This can be useful when handling or modifying results/violations manually. This allows to still rely on the default reporter and easily print the results without requiring to re-implement it when basic reporting is sufficient.