### PR TITLE
Function getAxeResults to return complete axe results

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ A class instance that implements the `Reporter` interface. Custom reporter insta
 
 Disables assertions based on violations and only logs violations to the console output. If you set `skipFailures` as `true`, although accessibility check is not passed, your test will not fail. It will simply print the violations in the console, but will not make the test fail.
 
-### getViolations
+### getAxeResults
 
-This will run axe against the document at the point in which it is called, then return you an array of accessibility violations.
+This will run axe against the document at the point in which it is called, then returns the full set of results as reported by `axe.run`.
 
-#### Parameters on getViolations (axe.run)
+#### Parameters on getAxeResults
 
 ##### page (mandatory)
 
@@ -141,22 +141,15 @@ Defines the scope of the analysis - the part of the DOM that you would like to a
 
 Set of options passed into rules or checks, temporarily modifying them. This contrasts with axe.configure, which is more permanent.
 
-The keys consist of [those accepted by `axe.run`'s options argument](https://www.deque.com/axe/documentation/api-documentation/#parameters-axerun) as well as custom `includedImpacts`, `detailedReport`, and `detailedReportOptions` keys.
+The object is of the same type which is [accepted by `axe.run`'s options argument](https://www.deque.com/axe/documentation/api-documentation/#parameters-axerun) and directly forwarded to it.
 
-The `includedImpacts` key is an array of strings that map to `impact` levels in violations. Specifying this array will only include violations where the impact matches one of the included values. Possible impact values are "minor", "moderate", "serious", or "critical".
+### getViolations
 
-Filtering based on impact in combination with the `skipFailures` argument allows you to introduce `axe-playwright` into tests for a legacy application without failing in CI before you have an opportunity to address accessibility issues. Ideally, you would steadily move towards stricter testing as you address issues.
-e-effects, such as adding custom output to the terminal.
+This will run axe against the document at the point in which it is called, then return you an array of accessibility violations (i.e. the `violations` array included in the `getAxeResults` result).
 
-**NOTE:** _This respects the `includedImpacts` filter and will only execute with violations that are included._
+#### Parameters on getViolations (axe.run)
 
-The `detailedReport` key is a boolean whether to print the more detailed report `detailedReportOptions` is an object with the shape
-
-```
-{
- html?: boolean // include the full html for the offending nodes
-}
-```
+Identical to [parameters of getAxeResults](#parameters-on-getAxeResults).
 
 ### reportViolations
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Check, ElementContext, ImpactValue, Locale, Result, Rule, RunOptions } from 'axe-core'
+import { AxeResults, Check, ElementContext, ImpactValue, Locale, Result, Rule, RunOptions } from 'axe-core'
 import { Page } from 'playwright'
 
 export interface axeOptionsConfig {
@@ -62,12 +62,20 @@ export function checkA11y(
 export function configureAxe(page: Page, options?: ConfigOptions): Promise<void>
 
 /**
+ * Runs axe-core tools on the relevant page and returns all results
+ * @param page
+ * @param context
+ * @param options
+ */
+ export function getAxeResults(page: Page, context?: ElementContext, options?: RunOptions): Promise<AxeResults[]>
+
+/**
  * Runs axe-core tools on the relevant page and returns all accessibility violations detected on the page
  * @param page
  * @param context
  * @param options
  */
-export function getViolations(page: Page, context?: ElementContext, options?: Options): Promise<Result[]>
+export function getViolations(page: Page, context?: ElementContext, options?: RunOptions): Promise<Result[]>
 
 /**
  * Report violations given the reporter.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright'
 import * as fs from 'fs'
-import { ElementContext, Result, RunOptions, Spec } from 'axe-core'
+import { AxeResults, ElementContext, Result, RunOptions, Spec } from 'axe-core'
 import { ConfigOptions, Options } from '../index'
 import { getImpactedViolations, testResultDependsOnViolations } from './utils'
 import DefaultTerminalReporter from './reporter/defaultTerminalReporter'
@@ -40,6 +40,27 @@ export const configureAxe = async (
 }
 
 /**
+ * Runs axe-core tools on the relevant page and returns all results
+ * @param page
+ * @param context
+ * @param options
+ */
+export const getAxeResults = async (
+  page: Page,
+  context?: ElementContext,
+  options?: RunOptions,
+): Promise<AxeResults> => {
+  const result = await page.evaluate(
+    ([context, options]) => {
+      return window.axe.run(context || window.document, options)
+    },
+    [context, options],
+  )
+
+  return result
+}
+
+/**
  * Runs axe-core tools on the relevant page and returns all accessibility violations detected on the page
  * @param page
  * @param context
@@ -48,16 +69,9 @@ export const configureAxe = async (
 export const getViolations = async (
   page: Page,
   context?: ElementContext,
-  options?: Options,
+  options?: RunOptions,
 ): Promise<Result[]> => {
-  const result = await page.evaluate(
-    ([context, options]) => {
-      const axeOptions: RunOptions = options ? options['axeOptions'] : {}
-      return window.axe.run(context || window.document, axeOptions)
-    },
-    [context, options],
-  )
-
+  const result = await getAxeResults(page, context, options)
   return result.violations
 }
 
@@ -85,7 +99,7 @@ export const checkA11y = async (
   skipFailures: boolean = false,
   reporter: Reporter = new DefaultTerminalReporter(options?.detailedReport, options?.detailedReportOptions?.html),
 ): Promise<void> => {
-  const violations = await getViolations(page, context, options)
+  const violations = await getViolations(page, context, options?.axeOptions)
 
   const impactedViolations = getImpactedViolations(
     violations,


### PR DESCRIPTION
Introduces a new function `getAxeResults` to retrieve the full axe results from the analysis. This can be used to return additional information currently not available, e.g. "review items" in the `incomplete` array, or passed checks.

Updates existing `getViolations` to use the new function internally and updates parameters and associated documentation (Readme listed multiple parameters which were actually unused in `getViolations` - probably a remnant of the `checkA11y` section copy?).

fixes #37 - can use the new function to get the full result which will include all data which is requested via the `resultTypes` option