### PR TITLE
Fixed `getViolations` options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,9 @@ describe('Playwright web page accessibility test', () => {
 
   it('gets and reports a11y for the specific element', async () => {
     const violations = await getViolations(page, 'input[name="password"]', {
-      axeOptions: {
-        runOnly: {
-          type: 'tag',
-          values: ['wcag2a'],
-        },
+      runOnly: {
+        type: 'tag',
+        values: ['wcag2a'],
       },
     })
 


### PR DESCRIPTION
The `getViolations` example wasn't working because run options were added to `options.axeOptions` instead of directly to the `options`.

Run options are only added to the `options.axeOptions` for `checkA11y`, not `getViolations`.