### PR TITLE
Fix incorrect peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release": "npm cache clean --force && npm version patch && npm publish --force"
   },
   "peerDependencies": {
-    "playwright-core": ">1.0.0"
+    "playwright": ">1.0.0"
   },
   "author": "Abhinaba Ghosh",
   "license": "MIT",


### PR DESCRIPTION
In the README.md you have listed playwright as a peer dependency instead of playwright-core. Playwright includes playwright-core. 