### PR TITLE
generate custom html report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ dist
 .DS_Store
 .idea/
 package-lock.json
+results
+artifacts
 
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `page` instance of `playwright`.
 
 Defines the scope of the analysis - the part of the DOM that you would like to analyze. This will typically be the document or a specific selector such as class name, ID, selector, etc.
 
-##### options (optional)
+##### axeOptions (optional)
 
 Set of options passed into rules or checks, temporarily modifying them. This contrasts with axe.configure, which is more permanent.
 
@@ -125,6 +125,11 @@ A class instance that implements the `Reporter` interface or values `default` an
 ##### skipFailures (optional, defaults to false)
 
 Disables assertions based on violations and only logs violations to the console output. If you set `skipFailures` as `true`, although accessibility check is not passed, your test will not fail. It will simply print the violations in the console, but will not make the test fail.
+
+##### options (dedicated for axe-html-reporter)
+
+Options dedicated for HTML reporter. 
+[axe-html-reporter](https://www.npmjs.com/package/axe-html-reporter)
 
 ### getAxeResults
 
@@ -279,6 +284,34 @@ describe('Playwright web page accessibility test', () => {
 ![Detailed Report](./docs/detailed-report-example.png)
 
 ![Detailed Report with HTML](./docs/detailed-report-html-example.png)
+
+#### HTML Report
+
+Thanks to [axe-html-reporter](https://www.npmjs.com/package/axe-html-reporter) you can generate HTML report(s).
+From default HTML file(s) will be generated under `/artifacts/accessibilityReport.html`. 
+Report's options can customized from `checkAlly` level:
+
+```
+await checkA11y(
+      page,
+      'form',
+      {
+        axeOptions: {
+          runOnly: {
+            type: 'tag',
+            values: ['wcag2a'],
+          },
+        },
+      },
+      true, 'default',
+      {
+        outputDirPath: 'results',
+        outputDir: 'accessibility',
+        reportFileName: 'accessibility-audit.html'
+      }
+    )
+```
+
 
 ## Before you Go
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axe-playwright",
-  "version": "1.1.12",
+  "version": "1.2.0",
   "description": "Custom Playwright commands to inject axe-core and test for a11y",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "picocolors": "^1.0.0",
-    "axe-core": "^4.5.1"
+    "axe-core": "^4.5.1",
+    "axe-html-reporter": "2.2.3"
   },
   "repository": {
     "type": "git",

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export default interface Reporter {
   report(violations: Result[]): Promise<void>
 }
 
-export type Options = {
+export type AxeOptions = {
   includedImpacts?: ImpactValue[]
   detailedReport?: boolean
   detailedReportOptions?: { html?: boolean }

--- a/test/a11y.spec.ts
+++ b/test/a11y.spec.ts
@@ -163,3 +163,45 @@ describe('Playwright web page accessibility test using verbose true on reporter 
     await browser.close()
   })
 })
+
+describe('Playwright web page accessibility test using generated html report with custom path', () => {
+  each([
+    [
+      'on page with detectable accessibility issues',
+      `file://${process.cwd()}/test/site.html`,
+    ],
+  ]).it('check a11y %s', async (description, site) => {
+    const log = jest.spyOn(global.console, 'log')
+
+    browser = await chromium.launch({ args: ['--no-sandbox'] })
+    page = await browser.newPage()
+    await page.goto(site)
+    await injectAxe(page)
+    await checkA11y(
+      page,
+      'form',
+      {
+        axeOptions: {
+          runOnly: {
+            type: 'tag',
+            values: ['wcag2a'],
+          },
+        },
+      },
+      true, 'default',
+      {
+        outputDirPath: 'results',
+        outputDir: 'accessibility',
+        reportFileName: 'accessibility-audit.html'
+      }
+    )
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching(/(accessibility|impact)/i),
+    )
+  })
+
+  afterEach(async () => {
+    await browser.close()
+  })
+})


### PR DESCRIPTION
Example for custom report:
```
await checkA11y(page, context, {
      axeOptions: {
        runOnly: {
          type: 'tag',
          values: ['wcag2a', 'wcag2aa', 'wcag21aa']
        }
      }
    }, false, 'default', {
      outputDirPath: 'your-results-directory',
      outputDir: 'your-output-directory',
      reportFileName: 'accessibility-audit-.html'
    })
```