### PR TITLE
Feature/select reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ The `verbose` key is a boolean to whether to print the message `No accessibility
 
 ##### reporter (optional)
 
-A class instance that implements the `Reporter` interface or values `default` and `v2`. Custom reporter instances can be supplied to override default reporting behaviour dictated by `DefaultTerminalReporter` set by the value `default`. `v2` is the new TerminalReporter inspired by the reports from [jest-axe](https://github.com/nickcolley/jest-axe).
+A class instance that implements the `Reporter` interface or values `default`, `v2` and `html`. Custom reporter instances can be supplied to override default reporting behaviour dictated by `DefaultTerminalReporter` set by the value `default`. `v2` is the new TerminalReporter inspired by the reports from [jest-axe](https://github.com/nickcolley/jest-axe). `html` reporter will generate external HTML file.
+
+Note! `html` reporter will disable printed to logs violations.
 
 ##### skipFailures (optional, defaults to false)
 

--- a/test/a11y.spec.ts
+++ b/test/a11y.spec.ts
@@ -188,7 +188,7 @@ describe('Playwright web page accessibility test using generated html report wit
           },
         },
       },
-      true, 'default',
+      false, 'html',
       {
         outputDirPath: 'results',
         outputDir: 'accessibility',


### PR DESCRIPTION
 `html` reporter will disable printed to logs violations

there is no point in having logged violations if all are under HTML file, but still, user can use e.g. `default` reporter (which will print everything as usually) and generate an external HTML file (still can disable such one by `doNotCreateReportFile` option)