### PR TITLE
Bump playwright from ^1.27.1 to ^1.41.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "jest": "^28.1.3",
         "jest-each": "^28.1.3",
         "jest-playwright-preset": "^2.0.0",
-        "playwright": "^1.27.1",
+        "playwright": "^1.41.1",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.8",
         "typescript": "^4.8.4"
@@ -3872,12 +3872,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
-      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.1.tgz",
+      "integrity": "sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.40.1"
+        "playwright-core": "1.41.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3890,9 +3890,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
-      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.1.tgz",
+      "integrity": "sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jest": "^28.1.3",
     "jest-each": "^28.1.3",
     "jest-playwright-preset": "^2.0.0",
-    "playwright": "^1.27.1",
+    "playwright": "^1.41.1",
     "prettier": "^2.7.1",
     "ts-jest": "^28.0.8",
     "typescript": "^4.8.4"


### PR DESCRIPTION
## What was done
I’m using this package for checking a11y by storybook test-runner.

When resolving packages, `playwright` package version is unintended that includes old chromium version.
So, it is bumped to latest playwright version to resolve playwright-chromium as intended.


Before
Resolved playwright version: `1.40.1`

it occurs test-runner fail like below:

![CleanShot 2024-01-24 at 17 23 27](https://github.com/abhinaba-ghosh/axe-playwright/assets/38889285/d0dc4b85-a821-4063-9931-b789e3483631)

After
Resolved playwright version: `1.41.1`
test-runner is succeeded.


## Additional Info
latest playwright-chromium version is updated in this pull request: https://github.com/microsoft/playwright/pull/28949