### PR TITLE
fix: Honor 'skipFailures: false' in HTML reporter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ export const checkA11y = async (
         results: { violations },
         options,
       } as CreateReport)
+      testResultDependsOnViolations(impactedViolations, skipFailures)
     } else console.log('There were no violations to save in report')
   } else if (reporter === 'junit') {
     // Get the system root directory

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export const checkA11y = async (
         results: { violations },
         options,
       } as CreateReport)
-      testResultDependsOnViolations(impactedViolations, skipFailures)
+      testResultDependsOnViolations(violations, skipFailures)
     } else console.log('There were no violations to save in report')
   } else if (reporter === 'junit') {
     // Get the system root directory


### PR DESCRIPTION
PR to fix #223 

Ensures failures are printed and the command fails as expected when `skipFailures` is set to `false` in the HTML reporter