### PR TITLE
checkA11y - `skipFailure` options not working when reporter is 'junit'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,10 +160,10 @@ export const checkA11y = async (
     reporterWithOptions = reporter
   }
 
-  if (reporter !== 'html')
+  if (reporter !== 'html' && reporter !== 'junit')
     await reportViolations(impactedViolations, reporterWithOptions)
 
-  if (reporter === 'v2' || (reporter !== 'html' && reporter !== 'junit'))
+  if (reporter === 'v2' || (reporter !== 'html'))
     testResultDependsOnViolations(impactedViolations, skipFailures)
 }
 


### PR DESCRIPTION
## Problem

I have the following usage of checkA11y function,
`skipFailures` is set to be `true`, and `reporter` is "junit".

```ts
    // Check a11y for current story and report results in JUnit format
    await checkA11y(page, element, {}, true, "junit", {
      outputDirPath: "test-results",
      outputDir: "a11y-audit",
      reportFileName: `${storyContext.title}.xml`,
    });
```

However, this setting gave me result like below, \
as if `skipFailures` option has no effect when `reporter` is set to "junit".

<img width="1027" alt="image" src="https://github.com/user-attachments/assets/8e7898c5-50d3-4ed0-bd26-8c1ac6bc70ec" />

## Changes

To fix this problem, I propose some changes in function `checkA11y()`.

### Result

By applying changes, now `skipFailures` option has effect like below.

|`false`|`true`|
|-|-|
|<img width="1025" alt="image" src="https://github.com/user-attachments/assets/11085f7a-da28-4f6b-b038-b7c04ce40b5b" />|<img width="1027" alt="image" src="https://github.com/user-attachments/assets/5daa8fb2-67e9-42e3-9cd5-d74ff50f30cc" />|
